### PR TITLE
Add Windows CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,4 +18,14 @@ jobs:
       with:
         name: editor
         path: target/release/editor
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --release
+    - uses: actions/upload-artifact@v2
+      with:
+        name: editor
+        path: target/release/editor.exe
 


### PR DESCRIPTION
Now that we don't have a shaderc dependency, Windows CI should work
fine.