### PR TITLE
Fix Debug vs Release Settings

### DIFF
--- a/engine/src/bin/editor.rs
+++ b/engine/src/bin/editor.rs
@@ -1,5 +1,7 @@
-#[cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use spark::engine::Engine;
+
 fn main() {
     let engine = Engine::new();
     engine.run();

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -108,7 +108,7 @@ impl Engine {
         let mut platform = WinitPlatform::init(&mut context);
         platform.attach_window(context.io_mut(), &window, HiDpiMode::Default);
 
-        let enable_validation = cfg!(debug_asserts);
+        let enable_validation = cfg!(debug_assertions);
         let renderer = Renderer::new(&window, enable_validation, &mut context)
             .expect("Failed to create renderer");
 


### PR DESCRIPTION
This changes fixes two unfortunate errors that were causing debug vs
release logic to fail. The Vulkan validation layers should now be
correctly enabled in debug builds and release build executables should
no longer show command prompts on Windows.