### PR TITLE
Updated ash Dependencies

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ash                 = "0.31"
-ash-window          = "0.5"
+ash                 = "0.32"
+ash-window          = "0.6"
 imgui               = "0.7"
 imgui-winit-support = "0.7"
 vk-mem              = "0.2"

--- a/vkutil/Cargo.toml
+++ b/vkutil/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ash        = "0.31"
-ash-window = "0.5"
+ash        = "0.32"
+ash-window = "0.6"
 vk-mem     = "0.2"
 winit      = "0.24"

--- a/vkutil/src/lib.rs
+++ b/vkutil/src/lib.rs
@@ -888,10 +888,11 @@ impl VkDescriptorPool {
         Ok(result[0])
     }
 
-    pub fn free_descriptor_set(&self, descriptor_set: vk::DescriptorSet) {
+    pub fn free_descriptor_set(&self, descriptor_set: vk::DescriptorSet) -> Result<()> {
         unsafe {
-            unwrap_device(&self.device).free_descriptor_sets(self.inner, &[descriptor_set]);
+            unwrap_device(&self.device).free_descriptor_sets(self.inner, &[descriptor_set])?;
         }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This commit updates spark to use ash 0.32 and ash-window 0.6. It also
makes the code changes required to continue building.